### PR TITLE
Add option to accept override for properties of the DPGlobal object

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ contributed to by him (yet?)
 
 Attached to a field with the format specified via options:
 
-    <input type="text" value="02-16-2012" id="datepicker">  
+    <input type="text" value="02-16-2012" id="datepicker">
 ######
     $('#datepicker').datepicker({
         format: 'mm-dd-yyyy'
@@ -103,6 +103,16 @@ A standalone .css file (including necessary dropdown styles and alternative, tex
 ## Options
 
 All options that take a "Date" can handle a `Date` object; a String formatted according to the given `format`; or a timedelta relative to today, eg '-1d', '+6m +1y', etc, where valid units are 'd' (day), 'w' (week), 'm' (month), and 'y' (year).
+
+Pass a space-separate list of values called `templateOverrides` that match a property `DPGlobal[thisProp]`, and then an HTML override separately in order to alter HTML templating, like this:
+
+```
+$().datepicker({
+    'templateOverrides' : 'headTemplate contTemplate',
+    'headTemplate'      : '<thead class="my-class">[...]</thead>',
+    'contTemplate'      : '<tbody class="my-class">[...]</tbody>'
+})
+```
 
 ### format
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -34,6 +34,21 @@
 		this.language = this.language in dates ? this.language : "en";
 		this.format = DPGlobal.parseFormat(options.format||this.element.data('date-format')||'mm/dd/yyyy');
                 this.isInline = false;
+
+		// pass an override to anything in DPGlobal with a simple space-separated list of values to override
+		// with the `templateOverrides` option - .datepicker({ 'templateOverrides' : 'headTemplate' });
+ 		if ( typeof options.templateOverrides !== "undefined" && options.templateOverrides !== null ) {
+	 		var templateOverrides = options.templateOverrides.split(' ');
+			if ( templateOverrides.length > 0 ) {
+				for ( var i=0; i<templateOverrides.length; i++ ) {
+					var thisOverride = templateOverrides[i];
+					var thisOrigTemplate = DPGlobal[thisOverride];
+					var newTemplate = DPGlobal.template.replace(new RegExp(thisOrigTemplate,'g'), options[thisOverride]);
+					DPGlobal.template = newTemplate;
+				}
+			}
+		}
+
 		this.isInput = this.element.is('input');
 		this.component = this.element.is('.date') ? this.element.find('.add-on') : false;
 		this.hasInput = this.component && this.element.find('input').length;
@@ -803,7 +818,7 @@
 								'</table>'+
 							'</div>'+
 						'</div>';
-                        
+
     $.fn.datepicker.DPGlobal = DPGlobal;
-    
+
 }( window.jQuery );


### PR DESCRIPTION
To use this option, declare the `templateOverrides` option as a space-separated list of values - which match a property of DPGlobal, and _also_ re-declare that property as an option,  like this

``` javascript
.datepicker({ 
    'templateOverrides' : 'headTemplate contTemplate',
    'headTemplate' : '<foo></foo>',
    'contTemplate' : '<bar></bar>',
});
```
