### PR TITLE
Trigger changeDate event also in input's keyup event

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -249,6 +249,7 @@
 
             if(fromArgs) this.setValue();
 
+			var oldViewDate = this.viewDate;
 			if (this.date < this.startDate) {
 				this.viewDate = new Date(this.startDate);
 			} else if (this.date > this.endDate) {
@@ -256,6 +257,14 @@
 			} else {
 				this.viewDate = new Date(this.date);
 			}
+
+			if (oldViewDate && oldViewDate.getTime() != this.viewDate.getTime()){
+				this.element.trigger({
+					type: 'changeDate',
+					date: this.date
+				});
+			}
+
 			this.fill();
 		},
 


### PR DESCRIPTION
As title says.
Before this change, writing date in the associated input didn't triggered the changeDate event.
