### PR TITLE
moved autoclose to work with non-inputs

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -581,10 +581,10 @@
 			}
 			if (element) {
 				element.change();
-				if (this.autoclose && (!which || which == 'date')) {
-					this.hide();
-				}
 			}
+      if (this.autoclose && (!which || which == 'date')) {
+        this.hide();
+      }
 		},
 
 		moveMonth: function(date, dir){


### PR DESCRIPTION
Autoclose does not work without an input, but they don't seem to be dependent on one another. I moved the check out of the input element check. But possibly they are related in some way I didn't notice?
